### PR TITLE
Simplify unfix header styling

### DIFF
--- a/styles/content_style.css
+++ b/styles/content_style.css
@@ -20,14 +20,12 @@ body .XPromoPopupRpl {
 }
 
 /* ---- Unfix header --- */
-body.header-unfix shreddit-app,
-body.header-unfix .App .NavFrame__below-top-nav {
-    padding-top: unset !important;
-}
-body.header-unfix .App .TopNav {
-    position: unset !important;
+body.header-unfix .App .TopNav,
+body.header-unfix shreddit-app > reddit-header-small {
+    position: absolute !important;
 }
 
+/* ---- Promoted content --- */
 .hide-promoted shreddit-ad-post,
 .hide-promoted .promotedlink,
 .hide-promoted hr + shreddit-ad-post + hr,


### PR DESCRIPTION
Current implementation does not work correctly on user and post pages. There's padding at the top removed but the header element is not unfixed which results in content going below the header. It's best to leave the padding intact and only override the fixed state (to position: absolute).